### PR TITLE
Dont use default reactor

### DIFF
--- a/lib/Connector.php
+++ b/lib/Connector.php
@@ -22,8 +22,8 @@ class Connector {
         self::OP_DISABLE_SNI_HACK => false
     ];
 
-    public function __construct(Reactor $reactor = null, Resolver $dnsResolver = null) {
-        $this->reactor = $reactor ?: \Amp\getReactor();
+    public function __construct(Reactor $reactor, Resolver $dnsResolver = null) {
+        $this->reactor = $reactor;
         $this->dnsResolver = $dnsResolver ?: new Resolver(new Client($reactor));
     }
 

--- a/lib/Encryptor.php
+++ b/lib/Encryptor.php
@@ -19,8 +19,8 @@ class Encryptor {
     /**
      * @param \Amp\Reactor $reactor
      */
-    public function __construct(Reactor $reactor = null) {
-        $this->reactor = $reactor ?: \Amp\getReactor();
+    public function __construct(Reactor $reactor) {
+        $this->reactor = $reactor;
         $this->hasOpenssl = extension_loaded('openssl');
         $this->isLegacy = $isLegacy = (PHP_VERSION_ID < 50600);
         $this->defaultCaFile = __DIR__ . '/../var/ca-bundle.crt';

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -16,7 +16,7 @@ use Amp\Future;
 function connect($authority, array $options = []) {
     static $connector;
     if (empty($connector)) {
-        $connector = new Connector;
+        $connector = new Connector(\Amp\getReactor());
     }
 
     return $connector->connect($authority, $options);
@@ -55,7 +55,7 @@ function cryptoConnect($authority, array $options = []) {
 function encrypt($stream, array $options = []) {
     static $encryptor;
     if (empty($encryptor)) {
-        $encryptor = new Encryptor;
+        $encryptor = new Encryptor(\Amp\getReactor());
     }
 
     return $encryptor->enable($stream, $options);


### PR DESCRIPTION
As discussed on t@lk, explicitly requiring the reactor makes sure lib users dont miss to pass in the reactor and there get problems e.g. while unit testing

This is a BC break